### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,7 +42,8 @@ async def manage_login(request: Request):
         return JSONResponse(status_code=200, content={"message": "Login successful", "token": current_jwt})
 
     except Et.ParseError as e:
-        return JSONResponse(status_code=400, content={"message": "Error parsing XML: " + str(e)})
+        logging.error("XML parse error during login request: %s", str(e))
+        return JSONResponse(status_code=400, content={"message": "Error parsing XML request."})
     except Exception as e:
         return JSONResponse(status_code=500,
                             content={"message": "Error parsing credentials or fetching JWT. " + str(e)})


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/3](https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/3)

To fix the problem, we should not send the stringified parsing error (`str(e)`) to the client. Instead, a generic error message should be returned to the client in the JSON response, and the internal (sensitive) error details should be logged on the server using the configured `logging` module. 

**Steps:**
- In `app/main.py`, within the `manage_login` endpoint, change the current handling of `Et.ParseError` exceptions at lines 44-45:
   - Instead of returning `JSONResponse(status_code=400, content={"message": "Error parsing XML: " + str(e)})`, log the error details and return a generic message such as `"Error parsing XML request."`.
   - No changes to imports are needed, as `logging` is already imported and configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
