### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,8 +44,9 @@ async def manage_login(request: Request):
     except Et.ParseError as e:
         return JSONResponse(status_code=400, content={"message": "Error parsing XML: " + str(e)})
     except Exception as e:
+        logging.error("Error in manage_login: %s", str(e), exc_info=True)
         return JSONResponse(status_code=500,
-                            content={"message": "Error parsing credentials or fetching JWT. " + str(e)})
+                            content={"message": "Internal server error"})
 
 @app.post("/create_record")
 async def manage_create_record(request: Request):


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/4](https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/4)

To fix this problem, the code should no longer send the full exception message (`str(e)`) back to the client in the HTTP response body on unexpected errors. Instead, a generic error message should be returned, such as "Internal server error," without including details that may originate from the exception. However, to aid debugging, the exception should be logged on the server with the full traceback.

Specifically:
- In app/main.py, within the `except Exception as e:` block in the `manage_login` function, replace the response that leaks the details (`"Error parsing credentials or fetching JWT. " + str(e)`) with a generic error message (e.g., `"Internal server error"`).
- Log the error server-side (using the `logging` module already imported) with traceback for developer reference.

The same pattern should apply elsewhere, but only the flagged instance on line 48 needs to be fixed per this request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
