### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -70,5 +70,6 @@ async def manage_create_record(request: Request):
     except ValueError as ve:
         return JSONResponse(status_code=400, content={"message": str(ve)})
     except Exception as e:
-        return JSONResponse(status_code=500, content={"message": "Internal server error: " + str(e)})
+        logging.exception("Internal server error encountered during record creation.")
+        return JSONResponse(status_code=500, content={"message": "Internal server error"})
 


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/6](https://github.com/SmartPotTech/SmartPot-Middleware/security/code-scanning/6)

To fix this issue, modify the generic error handler in the `/create_record` endpoint (lines 72–73) so that sensitive internal information contained in the exception `e` is not sent back in the HTTP response. Instead:
- Log the detailed exception (including stack trace, ideally) server-side using the configured logging.
- Return a generic error message (e.g., "Internal server error") to the client, without including the exception details.

This change should be performed only in the global exception handler for the `/create_record` endpoint (lines 72–73).  
To log stack traces with Python's logging, use `logging.exception(...)` or `logging.error("...", exc_info=True)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
